### PR TITLE
Fix typedef for byte.

### DIFF
--- a/c_src/elixir_comm.c
+++ b/c_src/elixir_comm.c
@@ -10,7 +10,7 @@
  * Helper function to read data from Erlang/Elixir from stdin.
  * Returns the number of bytes read (-1 on error), fills buffer with data.
  */
-static int read_input(byte* buffer, int length)
+static int read_input(char* buffer, int length)
 {
     int bytes_read = read(STDIN, buffer, length);
     if(bytes_read != length){
@@ -20,12 +20,12 @@ static int read_input(byte* buffer, int length)
     return bytes_read;
 }
 
-int read_msg(byte* buffer)
+int read_msg(char* buffer)
 {
     byte len[2]; //first 2 bytes contain length of the message.
     int length;
 
-    if(read_input(len, 2) != 2){
+    if(read_input((char*)len, 2) != 2){
         return -1;
     }
 
@@ -33,7 +33,7 @@ int read_msg(byte* buffer)
     return read_input(buffer, length);
 }
 
-void send_msg(byte* buffer, int length)
+void send_msg(char* buffer, int length)
 {
     byte len[2]; //first 2 bytes contain length of the message.
     len[0] = (length >> 8) & 0xff;
@@ -42,7 +42,7 @@ void send_msg(byte* buffer, int length)
     write(STDOUT, buffer, length);
 }
 
-void send_error(byte* error_message)
+void send_error(char* error_message)
 {
     send_msg(error_message, strlen(error_message));
 }

--- a/c_src/elixir_comm.h
+++ b/c_src/elixir_comm.h
@@ -7,24 +7,24 @@ extern "C" {
 
 #define MAX_BUFFER_SIZE 65535
 
-typedef char byte;
+typedef unsigned char byte;
 
 /*
  * Reads a message coming from Erlang/Elixir from stdin.
  * Returns the number of bytes read (-1 on error), fills the buffer with data.
  */
-int read_msg(byte* buffer);
+int read_msg(char* buffer);
 
 /*
  * Sends a message to Erlang/Elixir via stdout.
  */
-void send_msg(byte* buffer, int length);
+void send_msg(char* buffer, int length);
 
 /*
  * Helper function to send an error message back to Erlang/Elixir.
  * The message has to be a string that terminates with \0.
  */
-void send_error(byte* error_message);
+void send_error(char* error_message);
 
 
 #ifdef __cplusplus

--- a/test/cure_test.exs
+++ b/test/cure_test.exs
@@ -10,7 +10,17 @@ defmodule CureTest do
     end
     :ok
   end
-  
+
+  test "Test a message that overflows C 'signed char' size" do
+    data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    {:ok, server} = Cure.load @program_name
+
+    assert data == server |> Cure.send_data(data, :sync, 5000)
+
+    :ok = server |> Cure.stop
+  end
+
   test "Test normal workflow using :sync messages" do
     pid = self
     data1 = "testing 1,2,3"

--- a/test/test_echo_program.c
+++ b/test/test_echo_program.c
@@ -3,8 +3,8 @@
 int main(void)
 {
     int bytes_read;
-    byte buffer[MAX_BUFFER_SIZE];
-    
+    char buffer[MAX_BUFFER_SIZE];
+
     while((bytes_read = read_msg(buffer)) > 0)
     {
         send_msg(buffer, bytes_read); //Simply echo data back.


### PR DESCRIPTION
The following commit introduced a very serious but subtle bug:

https://github.com/luc-tielen/Cure/commit/80a108ade599dbb775bf86f2c25e2109636422c0#diff-99690a71d1c5923285b32f8a9fcb1d39L10

When byte is defined as 'char', a value such as 229 (which is 11100101 in
binary), would be -27 when read as a signed byte.

Output from test with the previous code:

```
  1) test Test a message that overflows C 'signed char' size (CureTest)
     test/cure_test.exs:14
     Assertion with == failed
     code:  data == server |> Cure.send_data(data, :sync, 5000)
     left:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     right: :timeout
     stacktrace:
       test/cure_test.exs:19: (test)
```